### PR TITLE
Allow local settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,12 +19,21 @@ I recommend using ``virtualenvwrapper`` to manage your virtual environments. Fol
    mkvirtualenv batucada 
    pip install -r requirements.txt 
 
+It is necessary to install the Python Image Libray: ::
+	
+   pip install pil
+   [FIXME: Can this be done automatically in the previous step?]
+   
+You may need to create a settings_local.py file to override some of the default settings.
+For example, you may need to `configure your email backend`_.
+   
 Finally, sync the database and start the development server. ::
 
    python manage.py syncdb --noinput 
    python manage.py runserver 
 
 .. _installation instructions: http://www.doughellmann.com/docs/virtualenvwrapper/
+.. _configure your email backend: http://docs.djangoproject.com/en/dev/topics/email/
 
 Get Involved
 ------------

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,12 @@
 
 import os
 
+try:
+    from settings_local import *
+except ImportError:
+    print u'File settings_local.py is not found. Continuing with production settings.'
+
+
 # Make filepaths relative to settings.
 ROOT = os.path.dirname(os.path.abspath(__file__))
 path = lambda *a: os.path.join(ROOT, *a)


### PR DESCRIPTION
In some environments default settings prevent batucada from working properly. For example, a machine that has no network connection (like on a plane for example) cannot send emails and so we need to use an alternative email backend if development is to be possible.

This pull request solves the problem by adding a setup_local.py file.

(I'm new to GIT and the associated workflows, so if I'm not doing this right please don't hesitate to tell me)
